### PR TITLE
Update BookingSummary.vue

### DIFF
--- a/src/components/BookingSummary.vue
+++ b/src/components/BookingSummary.vue
@@ -103,7 +103,6 @@
               </p>
               <v-radio label="No" value="false" light color="purple darken-4"/>
             </v-radio-group>
-
           </v-flex>
         </v-layout>
         <v-layout row wrap v-if="booking.giftaid==='true'">
@@ -177,12 +176,28 @@
             <v-select v-bind:items="years" v-model="booking.year" label="Select" light single-line auto />
           </v-flex>
           <v-flex xs6>
-            <v-subheader><a href="/refund" target="_blank">Refund policy (click here to read)</a></v-subheader>
+            <v-subheader>Refund policy:</v-subheader>
           </v-flex>
           <v-flex xs6>
+           <div class="container"><h3>King's College (Chapel and Grounds) tickets</h3> <div id="Refund"><h3>Refunds policy</h3> <ul><li>Tickets can only be exchanged or money refunded at the discretion of
+      the Head of Visitor Services or when the College is unexpectedly closed.</li> <li> Lost or stolen Tickets cannot be replaced or money refunded.</li> <li>Tickets are not transferable.</li></ul></div></div>
             <v-checkbox label="Accept refund policy" v-model="refundpolicy" light></v-checkbox>
 
           </v-flex>
+			
+			 <v-flex xs6>
+            <v-subheader>Privacy policy:</v-subheader>
+          </v-flex>
+          <v-flex xs6>
+			  <h3>Personal Data Usage Consent</h3> 
+			 <p>King’s College takes your privacy seriously.  We will only use your personal information to process and administer your request and to provide you with the services you have requested from us.  King’s College processes and stores personal information in accordance with the Data Protection Act, and the College’s Data Protection Policy <br><hr/></p>
+           <p><a href="http://www.kings.cam.ac.uk/about/data-protection.html" target="_blank">Click here to read more about King’s College Data Protection Policy</a></p>
+           <p>Please acknowledge that you have read the above information and give consent to the College to process and store your personal information. </p>
+			
+            <v-checkbox label="Click here to give consent" v-model="readprivacypolicy" light></v-checkbox>
+
+          </v-flex>
+			
           <v-flex xs12 class="text-xs-right">
             <v-btn
               @click.native="createbooking()"
@@ -227,6 +242,7 @@ export default {
       testmonth: 'false',
       testyear: 'false',
       refundpolicy: true,
+	  readprivacypolicy:false,
       fieldcomplete: false,
       uuid: '',
       countries: [],
@@ -319,13 +335,16 @@ export default {
     },
     refundpolicy () {
       this.testfields()
-    }
+    },
+	readprivacypolicy(){
+	  this.testfields()
+  }  
   },
   methods: {
     testfields () {
       this.fieldcomplete = ((this.testname === true) && (this.testemail === true) && (this.testaddress === true) &&
                             (this.testcity === true) && (this.testccnumber === true) && (this.testpostcode === true) &&
-                            (this.testcvv === true) && (this.refundpolicy === true))
+                            (this.testcvv === true) && (this.refundpolicy === true) && (this.readprivacypolicy === true))
     },
     evaluatepostcode () {
       if (this.country === 'United Kingdom') {


### PR DESCRIPTION
I added two rows at the bottom of the page to show both Refund and Privacy Policy.
I remove the refund policy link and set checkbox to false, this let user read and Accept refund policy and click to confirm they understand. The Accept refund policy landing page is not friendly.  
On the last row I have added the DPA statement with a checkbox and external link to full privacy policy.